### PR TITLE
Added support for disabling certificate validation when connecting to…

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,6 @@ The folder /cache is used for an image cache, this can be stored in
 | `-e API_KEY=xxxxxxxxx`                        | Specify the api key used to connect to stash if you have password protected your instance                     |
 | `-e CACHE_DIR=/cache/`                        | The directory used to cache images, defaults to /cache/ in the docker container and ./cache/ if not specified |
 | `-e DISABLE_CERT_VERIFICATION=True`           | Disable certificate verification when connecting to stash, for cases where https is used                      |
-| `-e DEOVR_USERNAME=user`                      | Username to require for authentication to the deovr endpoint                                                  |
-| `-e DEOVR_PASSWORD=xxxx`                      | Password to require for authentication to the deovr endpoint                                                  |
 
 ```
 docker stop stash-vr-companion

--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ The folder /cache is used for an image cache, this can be stored in
 | `-e API_URL=http://192.168.0.22:9999/graphql` | Specify the stash instance to connect to                                                                      |
 | `-e API_KEY=xxxxxxxxx`                        | Specify the api key used to connect to stash if you have password protected your instance                     |
 | `-e CACHE_DIR=/cache/`                        | The directory used to cache images, defaults to /cache/ in the docker container and ./cache/ if not specified |
+| `-e DISABLE_CERT_VERIFICATION=True`           | Disable certificate verification when connecting to stash, for cases where https is used                      |
+| `-e DEOVR_USERNAME=user`                      | Username to require for authentication to the deovr endpoint                                                  |
+| `-e DEOVR_PASSWORD=xxxx`                      | Password to require for authentication to the deovr endpoint                                                  |
 
 ```
 docker stop stash-vr-companion

--- a/app.py
+++ b/app.py
@@ -55,7 +55,6 @@ def __callGraphQL(query, variables=None):
         json['variables'] = variables
 
     # handle cookies
-    print(app.config['VERIFY_FLAG'])
     response = requests.post(app.config['GRAPHQL_API'], json=json, headers=headers, verify=app.config['VERIFY_FLAG'])
 
     if response.status_code == 200:

--- a/app.py
+++ b/app.py
@@ -8,12 +8,24 @@ from threading import Timer
 from pathlib import Path
 from datetime import datetime
 from apscheduler.schedulers.background import BackgroundScheduler
+from urllib3.exceptions import InsecureRequestWarning
 
 
 app = Flask(__name__)
 
 #app.config['SERVER_NAME'] = 'http://deovr.home'
 app.config['GRAPHQL_API'] = os.getenv('API_URL', 'http://localhost:9999/graphql')
+app.config['VERIFY_FLAG'] = not os.getenv('DISABLE_CERT_VERIFICATION', False)
+# Disable insecure certificate verification warning when cert validation is disabled
+if not app.config['VERIFY_FLAG']
+    requests.packages.urllib3.disable_warnings(category=InsecureRequestWarning)
+    
+if os.getenv('DEOVR_USERNAME') and os.getenv('DEOVR_PASSWORD')
+    app.config['BASIC_AUTH_USERNAME'] = os.getenv('DEOVR_USERNAME')
+    app.config['BASIC_AUTH_PASSWORD'] = os.getenv('DEOVR_PASSWORD')
+    # Setting this allows us to avoid flagging all endpoints as requiring the basic auth, so it can be conditional on
+    # whether the values are set.
+    app.config['BASIC_AUTH_FORCE'] = True
 
 app.secret_key = 'N46XYWbnaXG6JtdJZxez'
 
@@ -47,7 +59,7 @@ def __callGraphQL(query, variables=None):
         json['variables'] = variables
 
     # handle cookies
-    response = requests.post(app.config['GRAPHQL_API'], json=json, headers=headers)
+    response = requests.post(app.config['GRAPHQL_API'], json=json, headers=headers, verify=app.config['VERIFY_FLAG'])
 
     if response.status_code == 200:
         result = response.json()
@@ -860,7 +872,7 @@ def image_proxy():
     scene_id = request.args.get('scene_id')
     session_id = request.args.get('session_id')
     url=app.config['GRAPHQL_API'][:-8]+'/scene/'+scene_id+'/screenshot?'+session_id
-    r = requests.get(url,headers=headers)
+    r = requests.get(url, headers=headers, verify=app.config['VERIFY_FLAG'])
     return Response(r.content,content_type=r.headers['Content-Type'])
 
 
@@ -1036,7 +1048,7 @@ def refreshCache():
         if not os.path.exists(os.path.join(image_dir, s['id'])):
             print("fetching image: " + s['id'])
             screenshot = s['paths']['screenshot']
-            r = requests.get(screenshot, headers=headers)
+            r = requests.get(screenshot, headers=headers, verify=app.config['VERIFY_FLAG'])
             with open(os.path.join(image_dir, s['id']), "xb") as f:
                 f.write(r.content)
                 f.close()
@@ -1047,7 +1059,7 @@ def refreshCache():
         else:
             if s["updated_at"] != cache['image_cache'][s['id']]["updated"]:
                 screenshot = s['paths']['screenshot']
-                r = requests.get(screenshot, headers=headers)
+                r = requests.get(screenshot, headers=headers, verify=app.config['VERIFY_FLAG'])
                 with open(os.path.join(image_dir, s['id']), "wb") as f:
                     f.write(r.content)
                     f.close()


### PR DESCRIPTION
… stash, and ability to prompt for username and password when logging in with DeoVR

I found when I went to use stash-vr-companion, it failed due to using HTTPS on my stash instance (certificate validation errors). While theoretically the app could be configured to set custom trust stores, that's a lot of work when in practice the only endpoint it's connecting to is the one you specify that's presumably on your localhost or local network.

Similarly, stash-vr-companion doesn't allow for username/password, but I believe DeoVR does support basic auth flows.

I haven't tested these flows yet (don't have docker locally, and my server can't do builds), but I'll fake update the docker image later and test.