### PR TITLE
Add environment variable for refresh interval

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ The folder /hsp is used to store hsp files, these are configuration files used b
 | `-e CACHE_DIR=/cache/`                        | The directory used to cache images, defaults to /cache/ in the docker container and ./cache/ if not specified                                                                                       |
 | `-e HSP_DIR=/hsp/`                            | The directory used to store hsp files saved from within heresphere, defaults to ./hsp/ if not specified                                                                                             |
 | `-e DISABLE_CERT_VERIFICATION=True`           | Disable certificate verification when connecting to stash, for cases where https is used                                                                                                            |
+| `-e REFRESH_MINUTES=5`                        | Refresh interval of VR scene information cache, in minutes. Defaults to 5 minutes if not specified.                                                                                                 |
 
 ```
 docker stop stash-vr-companion

--- a/app.py
+++ b/app.py
@@ -2679,9 +2679,9 @@ setup()
 setup_image_cache()
 refreshCache()
 
-
+refresh_minutes = int(os.getenv("REFRESH_MINUTES", "5"))
 sched = BackgroundScheduler(daemon=True)
-sched.add_job(refreshCache, "interval", minutes=5)
+sched.add_job(refreshCache, "interval", minutes=refresh_minutes)
 sched.start()
 
 


### PR DESCRIPTION
I don't update my library very often, so no reason to refresh cache often. I left the default as the existing value of 5 minutes, and added the new environment variable to the README.